### PR TITLE
usage を入れて CPU とメモリを計測できるように

### DIFF
--- a/app/beamQuest/main.js
+++ b/app/beamQuest/main.js
@@ -7,7 +7,8 @@ var params = require('beamQuest/params'),
     entities = require('beamQuest/store/entities'),
     mapStore = require('beamQuest/store/maps'),
     FieldMapCtrl = require('beamQuest/ctrl/fieldMap'),
-    scheduler = require('beamQuest/scheduler');
+    scheduler = require('beamQuest/scheduler'),
+    usage = require('usage');
 
 exports.start = function(io) {
     var config = {
@@ -45,6 +46,15 @@ exports.start = function(io) {
         scheduler.update();
     }
 
+    function logUsage() {
+        "use strict";
+
+        usage.lookup(process.pid, function(err, result) {
+            logger.debug('cpu: ' + result.cpu + ', memory: ' + result.memory);
+        });
+    }
+
     setInterval(main, config.STEP_INTERVAL);
+    setInterval(logUsage, 1000);
 };
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "underscore": "1.5.2",
     "redis": "0.9.1",
     "log4js": "0.6.9",
-    "tmx-parser": "1.2.0"
+    "tmx-parser": "1.2.0",
+    "usage": "0.3.9"
   },
   "devDependencies": {
     "grunt": "~0.4.2",


### PR DESCRIPTION
こんな感じでログが出る

```
   info  - socket.io started
[2014-02-05 23:27:05.609] [INFO] BeamQuest - development
[2014-02-05 23:27:05.653] [INFO] BeamQuest - development
[2014-02-05 23:27:05.714] [INFO] BeamQuest - start
[2014-02-05 23:27:06.726] [DEBUG] BeamQuest - cpu: 2.5, memory: 32022528
[2014-02-05 23:27:07.729] [DEBUG] BeamQuest - cpu: 1, memory: 32124928
[2014-02-05 23:27:08.733] [DEBUG] BeamQuest - cpu: 0.5, memory: 32215040
[2014-02-05 23:27:09.734] [DEBUG] BeamQuest - cpu: 1, memory: 32342016
[2014-02-05 23:27:10.739] [DEBUG] BeamQuest - cpu: 0.5, memory: 32419840
```
