### PR TITLE
HPバーのちょっと上の方をクリックするとフォーカスを奪われるのを修正

### DIFF
--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -21,15 +21,17 @@ body {
 }
 
 #bq-message-container {
-    display: inline-block;
+    position: absolute;
+    bottom: 0px;
 }
 
 #bq-bar-container {
-    display: inline-block;
+    position: absolute;
+    left: 275px;
+    bottom: 11px;
 }
 
 #bq-hud {
-    width: 800px;
     position: absolute;
     bottom: 0;
     left: 10px;


### PR DESCRIPTION
このへんをクリックするとフォーカスが奪われてイラッとするので、各パーツをposition: absolute化した。
![46](https://f.cloud.github.com/assets/123964/2124888/7b3f33e4-9247-11e3-8304-04650a24b067.png)
