### PR TITLE
ドロップアイテムの表示改善

### DIFF
--- a/public/js/src/object/dropItem.js
+++ b/public/js/src/object/dropItem.js
@@ -25,10 +25,9 @@ bq.object.DropItem = bq.object.Object.extend({
             this.showName(this.model_.item.name);
         }
 
-        var pos = this.getPosition();
-        var moveTo = cc.RepeatForever.create(cc.BezierTo.create(1, [cc.p(pos.x, pos.y+10), cc.p(pos.x, pos.y-10), pos]));
-        this.runAction(moveTo);
-
+        // ふわふわさせる
+        var bezierTo = cc.RepeatForever.create(cc.BezierTo.create(1, [cc.p(pos.x, pos.y+10), cc.p(pos.x, pos.y-10), pos]));
+        this.runAction(bezierTo);
     },
 
     /**


### PR DESCRIPTION
・アイテム名のラベルを中央寄せ
・マップチップの絵と区別しやすいようにドロップアイテムは上下にふわふわするようにした
