### PR TITLE
ユニットテストのひな形を生成するスクリプトを追加

### DIFF
--- a/bin/generate_test.sh
+++ b/bin/generate_test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+JS_FILE="$1"
+TEST_FILE=$(echo $JS_FILE | sed "s/\.[^.]*$//g")Spec.js
+if [ -f $TEST_FILE ]; then
+  echo "Test file already exists: $TEST_FILE" 1>&2
+  exit 1
+fi
+
+FILE_NAME=$(echo $JS_FILE | sed "s/\.[^.]*$//g")
+BASE_PATH=$(cd $(dirname $0); pwd)
+TEST_TEMPLATE_FILE=$BASE_PATH/test_template.js
+cat $TEST_TEMPLATE_FILE | sed -e "s%{{FILE_NAME}}%$FILE_NAME%g" > $TEST_FILE
+echo "Test file generated: $TEST_FILE"

--- a/bin/test_template.js
+++ b/bin/test_template.js
@@ -1,0 +1,19 @@
+var init = require('beamQuest/init'),
+    expect = require('expect.js'),
+    sinon = require('sinon');
+
+describe('Test: {{FILE_NAME}}', function() {
+    beforeEach(function() {
+        // 前処理
+    });
+
+    afterEach(function() {
+        // 後処理
+    });
+
+    it('', function() {
+        // ここにテストケースを書く
+        // 評価はexpectを使う (e.g) expect(actual).to.be(expected);
+    });
+
+});


### PR DESCRIPTION
``` bash
$ ./bin/generate_test.sh app/beamQuest/ctrl/fieldMap.js 
```

こんなかんじでユニットテストを書きたいjsファイルを渡してあげると、
必要最低限がそろった*Spec.jsを生成してくれるようになります。

ユニットテストを書く時にぜひご利用ください。

@nise-nabe @iwag @lettas 
