### PR TITLE
GoBehind がないマップを読み込んだ時に表示されないのでなくても表示するように

### DIFF
--- a/public/js/src/scene/beamQuest.js
+++ b/public/js/src/scene/beamQuest.js
@@ -12,7 +12,9 @@ bq.scene.BeamQuestWorld = cc.Layer.extend({
         tileMap.setPosition(cc.p(0,0));
 
         var behindMapLayer = tileMap.getLayer('GoBehind');
-        behindMapLayer.setLocalZOrder(bq.config.zOrder.BEHIND_LAYER);
+        if (behindMapLayer) {
+            behindMapLayer.setLocalZOrder(bq.config.zOrder.BEHIND_LAYER);
+        }
         var mapManager = new bq.MapManager(tileMap);
         bq.mapManager = mapManager;
 


### PR DESCRIPTION
新しくマップを追加した時に背後に回る必要がないマップを作成した時に表示されない

マップを作る手順とかあれば GoBehind が必要なことがわかるドキュメントかなくても動くようにするかで後者の修正
