### PR TITLE
redis の保存のデータ型を文字列（json）からハッシュ型に変更する 第一弾

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
 - '0.10'
 - '0.12'
+services:
+- redis-server
 before_script:
 - npm install -g grunt-cli
 deploy:

--- a/app.js
+++ b/app.js
@@ -15,7 +15,8 @@ var expressLogWrapper = log4js.getLogger('express');
 var env = process.env.NODE_ENV || 'development';
 
 if ('development' == env) {
-    expressLogWrapper.setLevel('INFO');
+    //expressLogWrapper.setLevel('INFO');
+    expressLogWrapper.setLevel('WARN');
 }
 
 if ('production' == env || 'heroku' == env) {

--- a/app/beamQuest/init.js
+++ b/app/beamQuest/init.js
@@ -3,7 +3,5 @@
  */
 
 require('beamQuest/params/params');
-var log4js = require('log4js');
 _ = require('underscore');
-logger = log4js.getLogger('BeamQuest');
-
+logger = require('./logger');

--- a/app/beamQuest/listener/login.ts
+++ b/app/beamQuest/listener/login.ts
@@ -28,10 +28,18 @@ export function listen(socket, io) {
             }
 
             if (userData && userData.hash !== loginData.hash) {
+                logger.debug('user login failed');
                 return respond_({result: 'error', message: 'すでに存在するキャラクターです。'});
             }
 
-            var player = (userData) ? createPlayer_(userData) : createNewPlayer_(loginData);
+            var player;
+            if (userData) {
+                logger.debug('user login successed');
+                player = createPlayer_(userData)
+            } else {
+                logger.debug('user created and login');
+                player = createNewPlayer_(loginData);
+            }
             addLoginUser_(player);
 
             return respond_({result: 'success', player: player.model.toJSON()});

--- a/app/beamQuest/listener/login.ts
+++ b/app/beamQuest/listener/login.ts
@@ -100,6 +100,7 @@ export function listen(socket, io) {
         UserStore.getInstance().saveSessionData(socket.id, 'mapId', player.model.position.mapId);
         player.scheduleUpdate();
         socket.broadcast.emit('notify:user:login', {'userId': model.id});
+        logger.debug('user login notified: userId "' + model.id + '" in ' + player.model.position.mapId);
 
         // 接続が切れたらログアウト扱い
         socket.on('disconnect', function() {

--- a/app/beamQuest/listener/login.ts
+++ b/app/beamQuest/listener/login.ts
@@ -3,6 +3,9 @@ import PlayerCtrl = require('beamQuest/ctrl/player');
 import PositionModel = require('beamQuest/model/position');
 import Entities = require('beamQuest/store/entities');
 import UserStore = require('beamQuest/store/userStore');
+
+declare var logger: any;
+
 var kvs = require('beamQuest/store/kvs').createClient();
 
 export function listen(socket, io) {
@@ -96,6 +99,7 @@ export function listen(socket, io) {
             Entities.getInstance().removePlayer(position.mapId, player);
             player.unscheduleUpdate();
             socket.broadcast.emit('notify:user:logout', {'userId': player.model.id});
+            logger.debug('socket.io connection closed');
         });
     }
 }

--- a/app/beamQuest/logger.ts
+++ b/app/beamQuest/logger.ts
@@ -1,0 +1,5 @@
+/// <reference path="../../typings/tsd.d.ts" />
+
+import log4js = require('log4js');
+
+module.exports = log4js.getLogger('BeamQuest');

--- a/app/beamQuest/main.js
+++ b/app/beamQuest/main.js
@@ -68,7 +68,7 @@ exports.start = function(io) {
             socket.emit('connected');
         });
         setInterval(main, config.STEP_INTERVAL);
-        setInterval(logUsage, 1000);
+        //setInterval(logUsage, 1000);
     }
 
     function main() {

--- a/app/beamQuest/main.js
+++ b/app/beamQuest/main.js
@@ -52,6 +52,8 @@ exports.start = function(io) {
 
 
         io.sockets.on('connection', function(socket) {
+            logger.debug('socket.io connection start');
+
             login.listen(socket, io);
             World.getInstance().listen(socket);
             Beam.getInstance().listen(socket, io);
@@ -66,6 +68,7 @@ exports.start = function(io) {
             });
 
             socket.emit('connected');
+            logger.debug('socket.io connection established');
         });
         setInterval(main, config.STEP_INTERVAL);
         //setInterval(logUsage, 1000);

--- a/app/beamQuest/store/kvs.ts
+++ b/app/beamQuest/store/kvs.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../../typings/tsd.d.ts" />
+/// <reference path="../../../typings/config/config.d.ts" />
 
 import redis = require('redis');
 import config = require('config');

--- a/app/beamQuest/store/kvs.ts
+++ b/app/beamQuest/store/kvs.ts
@@ -8,14 +8,16 @@ declare var logger: any;
 
 var CONFIG = config.kvs;
 
+logger.info('kvs type: ' + CONFIG.type);
+
 /**
  * 拡張可能なようにラップ
  */
 export interface Client extends redis.RedisClient {
 }
 
+
 export function createClient(): Client {
-    logger.info('kvs type: ' + CONFIG.type);
     if (CONFIG.type !== 'redis') {
         throw new Error('not supported kvs type');
     }

--- a/app/beamQuest/store/kvs.ts
+++ b/app/beamQuest/store/kvs.ts
@@ -1,5 +1,4 @@
-/// <reference path="../../../typings/node_redis/node_redis.d.ts" />
-/// <reference path="../../../typings/config/config.d.ts" />
+/// <reference path="../../../typings/tsd.d.ts" />
 
 import redis = require('redis');
 import config = require('config');

--- a/app/beamQuest/store/kvs.ts
+++ b/app/beamQuest/store/kvs.ts
@@ -8,7 +8,13 @@ declare var logger: any;
 
 var CONFIG = config.kvs;
 
-export function createClient(): any {
+/**
+ * 拡張可能なようにラップ
+ */
+export interface Client extends redis.RedisClient {
+}
+
+export function createClient(): Client {
     logger.info('kvs type: ' + CONFIG.type);
     if (CONFIG.type !== 'redis') {
         throw new Error('not supported kvs type');

--- a/app/beamQuest/store/kvs.ts
+++ b/app/beamQuest/store/kvs.ts
@@ -7,74 +7,12 @@ declare var logger: any;
 
 var CONFIG = config.kvs;
 
-/**
- * @fileoverview オンメモリのKVS的なやつ。redisに置き換える？
- */
-class SessionStore {
-    private static instance_:SessionStore;
-    public static getInstance():SessionStore {
-        if (SessionStore.instance_ === undefined) {
-            SessionStore.instance_ = new SessionStore();
-        }
-        return SessionStore.instance_;
-    }
-
-    constructor() {
-        if (SessionStore.instance_){
-            throw new Error("Error: Instantiation failed: Use SessionStore.getInstance() instead of new.");
-        }
-        SessionStore.instance_ = this;
-
-        this.session_ = {};
-        this.isEnd =  false;
-    }
-
-    private session_: Object;
-    private isEnd: boolean;
-
-    get(key, callback) {
-        if (this.isEnd) {
-            callback('connection already closed', null);
-        }
-        if (key in this.session_) {
-            callback(null, this.session_[key]);
-        }
-        else {
-            callback(null, null);
-        }
-    }
-
-    set(key, value) {
-        this.session_[key] = value;
-    }
-
-    del(key) {
-        delete this.session_[key];
-    }
-
-    flushall(callback) {
-        if (this.isEnd) {
-            callback(false);
-        }
-        this.session_ = {};
-        logger.info('kvs flushall');
-        callback(true);
-    }
-
-    end() {
-        this.isEnd = true;
-    }
-
-}
-
 export function createClient(): any {
     logger.info('kvs type: ' + CONFIG.type);
-    if (CONFIG.type === 'memory') {
-        return SessionStore.getInstance();
-    } else if (CONFIG.type === 'redis') {
-        var client = redis.createClient(CONFIG.port, CONFIG.host);
-        client.auth(CONFIG.pass);
-        return client;
+    if (CONFIG.type !== 'redis') {
+        throw new Error('not supported kvs type');
     }
-    return null;
+    var client = redis.createClient(CONFIG.port, CONFIG.host);
+    client.auth(CONFIG.pass);
+    return client;
 }

--- a/app/beamQuest/store/userStore.ts
+++ b/app/beamQuest/store/userStore.ts
@@ -18,7 +18,7 @@ class UserStore {
         this.store = kvs.createClient();
     }
 
-    store;
+    store:kvs.Client;
 
     private getStoreKey_(userId) {
         return "user:" + userId;

--- a/config/test.js
+++ b/config/test.js
@@ -1,8 +1,12 @@
 module.exports = {
     kvs: {
-        type: "memory"
+        type: "redis",
+        host: "localhost",
+        port: 6380
     },
     session: {
-        type: "memory"
+        type: "redis",
+        host: "localhost",
+        port: 6380
     }
 };

--- a/config/test.js
+++ b/config/test.js
@@ -2,11 +2,11 @@ module.exports = {
     kvs: {
         type: "redis",
         host: "localhost",
-        port: 6380
+        port: 6379
     },
     session: {
         type: "redis",
         host: "localhost",
-        port: 6380
+        port: 6379
     }
 };

--- a/tsd.json
+++ b/tsd.json
@@ -31,6 +31,9 @@
     },
     "mocha/mocha.d.ts": {
       "commit": "c8b6954f449bd252ee42592fe471f14b1995cffb"
+    },
+    "log4js/log4js.d.ts": {
+      "commit": "9585a3b741a8491d5c883249515fd00b45b0a9f9"
     }
   }
 }

--- a/typings/log4js/log4js.d.ts
+++ b/typings/log4js/log4js.d.ts
@@ -1,33 +1,138 @@
-///<reference path='../node/node.d.ts' />
+// Type definitions for log4js
+// Project: https://github.com/nomiddlename/log4js-node
+// Definitions by: Kentaro Okuno <http://github.com/armorik83>
+// Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare var levels: string;
+/// <reference path="../express/express.d.ts" />
 
 declare module "log4js" {
-    export function getLogger(categoryName: string): Logger;
-    export function connectLogger(logger4js: any, options: any): any;
+  import express = require('express');
 
-    interface Logger {
-        setLevel(string): void;
+  /**
+   * Get a logger instance. Instance is cached on categoryName level.
+   *
+   * @param   {String} [categoryName] name of category to log to.
+   * @returns {Logger} instance of logger for the category
+   * @static
+   */
+  export function getLogger(categoryName?: string): Logger;
+  export function getBufferedLogger(categoryName?: string): Logger;
+
+  /**
+   * Has a logger instance cached on categoryName.
+   *
+   * @param   {String} [categoryName] name of category to log to.
+   * @returns {boolean} contains logger for the category
+   * @static
+   */
+  export function hasLogger(categoryName: string): boolean;
+
+  /**
+   * Get the default logger instance.
+   *
+   * @returns {Logger} instance of default logger
+   * @static
+   */
+  export function getDefaultLogger(): Logger;
+
+  /**
+   * args are appender, then zero or more categories
+   *
+   * @param   {*[]} appenders
+   * @returns {void}
+   * @static
+   */
+  export function addAppender(...appenders: any[]): void;
+
+  /**
+   * Claer configured appenders
+   *
+   * @returns {void}
+   * @static
+   */
+  export function clearAppenders(): void;
+
+  /**
+   * Shutdown all log appenders. This will first disable all writing to appenders
+   * and then call the shutdown function each appender.
+   *
+   * @params  {Function} cb - The callback to be invoked once all appenders have
+   *  shutdown. If an error occurs, the callback will be given the error object
+   *  as the first argument.
+   * @returns {void}
+   */
+  export function shutdown(cb: Function): void;
+
+  export function configure(config: IConfig, options?: any): void;
+
+  export function setGlobalLogLevel(level: string): void;
+  export function setGlobalLogLevel(level: Level): void;
 
 
-    }
+  /**
+   * Create logger for connect middleware.
+   *
+   *
+   * @returns {express.Handler} Instance of middleware.
+   * @static
+   */
+  export function connectLogger(logger: Logger, options: { format?: string; level?: string; nolog?: any; }): express.Handler;
+  export function connectLogger(logger: Logger, options: { format?: string; level?: Level; nolog?: any; }): express.Handler;
 
 
-    export module levels {
-        var ALL:   Level;
-        var TRACE: Level;
-        var DEBUG: Level;
-        var INFO:  Level;
-        var WARN:  Level;
-        var ERROR: Level;
-        var FATAL: Level;
-        var OFF:   Level;
+  export var appenders: any;
+  export var levels: {
+    ALL: Level;
+    TRACE: Level;
+    DEBUG: Level;
+    INFO: Level;
+    WARN: Level;
+    ERROR: Level;
+    FATAL: Level;
+    OFF: Level;
 
-        function toLevel(sArg: string, defaultLevel: Level): Level;
-    }
+    toLevel(level: string, defaultLevel?: Level): Level;
+    toLevel(level: Level, defaultLevel?: Level): Level;
+  };
 
-    interface Level {
-        level: Number;
-        levelStr: string;
-    }
+  export interface Logger {
+    setLevel(level: string): void;
+    setLevel(level: Level): void;
+
+    isLevelEnabled(level: Level): boolean;
+    isTraceEnabled(): boolean;
+    isDebugEnabled(): boolean;
+    isInfoEnabled(): boolean;
+    isWarnEnabled(): boolean;
+    isErrorEnabled(): boolean;
+    isFatalEnabled(): boolean;
+
+    trace(message: string, ...args: any[]): void;
+    debug(message: string, ...args: any[]): void;
+    info(message: string, ...args: any[]): void;
+    warn(message: string, ...args: any[]): void;
+    error(message: string, ...args: any[]): void;
+    fatal(message: string, ...args: any[]): void;
+  }
+
+  export interface Level {
+    isEqualTo(other: string): boolean;
+    isEqualTo(otherLevel: Level): boolean;
+    isLessThanOrEqualTo(other: string): boolean;
+    isLessThanOrEqualTo(otherLevel: Level): boolean;
+    isGreaterThanOrEqualTo(other: string): boolean;
+    isGreaterThanOrEqualTo(otherLevel: Level): boolean;
+  }
+
+  export interface IConfig {
+    appenders: IAppenderConfig[];
+    levels?: { [category: string]: string };
+    replaceConsole?: boolean;
+  }
+  export interface IAppenderConfig {
+    type: string;
+    category?: string[];
+    // etc...
+  }
 }
+

--- a/typings/tsd.d.ts
+++ b/typings/tsd.d.ts
@@ -7,3 +7,4 @@
 /// <reference path="sinon/sinon.d.ts" />
 /// <reference path="expect.js/expect.js.d.ts" />
 /// <reference path="mocha/mocha.d.ts" />
+/// <reference path="log4js/log4js.d.ts" />


### PR DESCRIPTION
json を文字列としてそのまま入れるとデータの確認とか変更とか大変なので `hash key value` の形で保存するようにして redis-cli で  `hget user:nabe mapId` や `hset user:nabe mapId 2` のように変更できるようにしたい．

その過程で hmset/hmget 使おうとしてるんだけどちょっと変えただけで全く動かなくし何が起きてるかさっぱりわからんので一旦ログ整備することにした．（まだ全然足りない）

* redis だけサポートするように変更
* usage コメントアウト
  * いまんところ役に立ってない
* socket.io の connect/disconnect 
  * これないとクライアントから接続成功したか失敗したかすらわからん
* login の broadcast 