### PR TITLE
無駄そうな proxy を削除

### DIFF
--- a/public/js/src/mapManager.js
+++ b/public/js/src/mapManager.js
@@ -78,11 +78,11 @@ bq.MapManager = cc.Class.extend({
      * @param {Object.<Object>} itemJsons
      */
     addDropItems: function(itemJsons) {
-        _.forEach(itemJsons, $.proxy(function(itemJson) {
+        _.forEach(itemJsons, function(itemJson) {
             var item =  new bq.object.DropItem(new bq.model.DropItem(itemJson));
             bq.baseLayer.addChild(item, bq.config.zOrder.DROP_ITEM);
             this.dropItems_[itemJson['dropId']] = item;
-        }), this);
+        }, this);
     },
 
     /**


### PR DESCRIPTION
function 内の this で dropItems_ を参照しようとしてるんだろうけど $.proxy の括弧対応がおそらく間違ってて this が変わってない。

ただ _.forEach の 第３引き数が context なので偶然動いてたのをもう _.forEach の conext 使ってしまえよという修正。